### PR TITLE
FIP-6 refine tests to use 50 locking periods. add max tests

### DIFF
--- a/tests/transfer-locked-tokens.js
+++ b/tests/transfer-locked-tokens.js
@@ -82,6 +82,7 @@ describe(`************************** transfer-locked-tokens.js *****************
         tpid: '',
 
       })
+      expect(result.status).to.not.equal('OK')
 
     } catch (err) {
       var expected = `Error 400`
@@ -109,6 +110,7 @@ describe(`************************** transfer-locked-tokens.js *****************
         tpid: '',
 
       })
+      expect(result.status).to.not.equal('OK')
 
     } catch (err) {
       var expected = `Error 400`
@@ -136,6 +138,7 @@ describe(`************************** transfer-locked-tokens.js *****************
         tpid: '',
 
       })
+      expect(result.status).to.not.equal('OK')
 
     } catch (err) {
       var expected = `Error 400`
@@ -163,6 +166,7 @@ describe(`************************** transfer-locked-tokens.js *****************
         tpid: '',
 
       })
+      expect(result.status).to.not.equal('OK')
     } catch (err) {
       var expected = `Error 400`
       expect(err.message).to.include(expected)
@@ -189,6 +193,231 @@ describe(`************************** transfer-locked-tokens.js *****************
         tpid: '',
 
       })
+      expect(result.status).to.not.equal('OK')
+    } catch (err) {
+      var expected = `Error 400`
+      expect(err.message).to.include(expected)
+    }
+  })
+
+  it(`Too many lock periods, fail`, async () => {
+    try {
+      const result = await userA4.sdk.genericAction('transferLockedTokens', {
+        payeePublicKey: keys2.publicKey,
+        canVote: false,
+        periods: [
+          {
+            duration: 1,
+            percent: 0.273,
+          },
+          {
+            duration: 2,
+            percent: .273,
+          },
+          {
+            duration: 3,
+            percent: .273,
+          },
+          {
+            duration: 4,
+            percent: .273,
+          },
+          {
+            duration: 5,
+            percent: .273,
+          },
+          {
+            duration: 6,
+            percent: .273,
+          },
+          {
+            duration: 7,
+            percent: .273,
+          },
+          {
+            duration: 8,
+            percent: .273,
+          },
+          {
+            duration: 9,
+            percent: .273,
+          },
+          {
+            duration: 10,
+            percent: .273,
+          },
+          {
+            duration: 11,
+            percent: .273,
+          },
+          {
+            duration: 12,
+            percent: .273,
+          },
+          {
+            duration: 13,
+            percent: .273,
+          },
+          {
+            duration: 14,
+            percent: .273,
+          },
+          {
+            duration: 15,
+            percent: .273,
+          },
+          {
+            duration: 16,
+            percent: .273,
+          },
+          {
+            duration: 17,
+            percent: .273,
+          },
+          {
+            duration: 18,
+            percent: .273,
+          },
+          {
+            duration: 19,
+            percent: .273,
+          },
+          {
+            duration: 20,
+            percent: .273,
+          },
+          {
+            duration: 21,
+            percent: .273,
+          },
+          {
+            duration: 22,
+            percent: .273,
+          },
+          {
+            duration: 23,
+            percent: .273,
+          },
+          {
+            duration: 24,
+            percent: .273,
+          },
+          {
+            duration: 25,
+            percent: .273,
+          },
+          {
+            duration: 26,
+            percent: .273,
+          },
+          {
+            duration: 27,
+            percent: .273,
+          },
+          {
+            duration: 28,
+            percent: .273,
+          },
+          {
+            duration: 29,
+            percent: .273,
+          },
+          {
+            duration: 30,
+            percent: .273,
+          },
+          {
+            duration: 31,
+            percent: .273,
+          },
+          {
+            duration: 32,
+            percent: .273,
+          },
+          {
+            duration: 33,
+            percent: .273,
+          },
+          {
+            duration: 34,
+            percent: .273,
+          },
+          {
+            duration: 35,
+            percent: .273,
+          },
+          {
+            duration: 36,
+            percent: .273,
+          },
+          {
+            duration: 37,
+            percent: .273,
+          },
+          {
+            duration: 38,
+            percent: .273,
+          },
+          {
+            duration: 39,
+            percent: .273,
+          },
+          {
+            duration: 40,
+            percent: .273,
+          },
+          {
+            duration: 41,
+            percent: .273,
+          },
+          {
+            duration: 42,
+            percent: .273,
+          },
+          {
+            duration: 43,
+            percent: .273,
+          },
+          {
+            duration: 44,
+            percent: .273,
+          },
+          {
+            duration: 45,
+            percent: .273,
+          },
+          {
+            duration: 46,
+            percent: .273,
+          },
+          {
+            duration: 47,
+            percent: .273,
+          },
+          {
+            duration: 48,
+            percent: .273,
+          },
+          {
+            duration: 49,
+            percent: .273,
+          },
+          {
+            duration: 50,
+            percent: .273,
+          },
+          {
+            duration: 51,
+            percent: 86.35,
+          }
+        ],
+        amount: fundsAmount,
+        maxFee: 400000000000,
+        tpid: '',
+
+      })
+      expect(result.status).to.not.equal('OK')
+
     } catch (err) {
       var expected = `Error 400`
       expect(err.message).to.include(expected)
@@ -407,7 +636,6 @@ describe(`************************** transfer-locked-tokens.js *****************
       console.log('Error', err)
     }
   })
-
 
 
   it(`Get bp1@dapixdev total_votes before locked account votes`, async () => {

--- a/tests/transfer-locked-tokens.js
+++ b/tests/transfer-locked-tokens.js
@@ -20,6 +20,7 @@ let userA1, userA2, userA3, userA4, keys, keys1, keys2, keys3, locksdk,
     locksdk1, locksdk2, locksdk3, newFioAddress, newFioDomain, newFioDomain2, newFioAddress2,
     total_bp_votes_before, total_bp_votes_after
 const fundsAmount = 500000000000
+const maxTestFundsAmount = 5000000000
 const halfundsAmount = 230000000000
 
 describe(`************************** transfer-locked-tokens.js ************************** \n A. Create accounts for tests`, () => {
@@ -211,8 +212,6 @@ After tokens are proxied and the proxy votes unlocked token weight is voted
 
 Register FIO Address can be paid with unlocked tokens
 */
-
-
 
 describe(`************************** transfer-locked-tokens.js ************************** \n B. 2 unlock periods, Canvote set to false tests`, () => {
 
@@ -422,9 +421,7 @@ describe(`************************** transfer-locked-tokens.js *****************
   //end check that we arent abl to vote with this lock
 })
 
-
 //end new tests matching testing requirements.
-
 
 
 describe(`************************** transfer-locked-tokens.js ************************** \n C. Canvote true, verify tokens are voted.`, () => {
@@ -542,8 +539,6 @@ describe(`************************** transfer-locked-tokens.js *****************
   })
 })
 
-
-
 describe(`************************** transfer-locked-tokens.js ************************** \n D. Token unlocking tests`, () => {
 
   it(`Transfer ${fundsAmount} locked FIO using canvote false, two lock periods of 20 sec and 50 percent`, async () => {
@@ -554,11 +549,51 @@ describe(`************************** transfer-locked-tokens.js *****************
         periods: [
           {
             duration: 20,
-            percent: 50.0,
+            percent: 45.0,
           },
           {
             duration: 20,
-            percent: 50.0,
+            percent: 45.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
+          },
+          {
+            duration: 20,
+            percent: 1.0,
           }
         ],
         amount: fundsAmount,
@@ -637,4 +672,65 @@ it(`Transfer ${halfundsAmount} FIO to another account`, async () => {
 
 })
 
+
+let accounts = [], privkeys = [], pubkeys = []
+let lockholder
+
+//comment out other tests, then run this test, then after running, re-run the other tests in order to test the
+//system loaded up with a decent number of general locked token grants.
+describe(`************************** transfer-locked-tokens.js ************************** \n E. MAX tests`, () => {
+
+  it.skip(`load the protocol with 50k general grants`, async () => {
+    try {
+
+
+      for (let step = 0; step < 50000; step++) {
+
+        try {
+
+          if (step % 100 == 0){
+            userA4 = await newUser(faucet);
+            console.log("created another granting user")
+          }
+          keys = await createKeypair();
+          accounts.push(keys.account)
+          privkeys.push(keys.privateKey)
+          pubkeys.push(keys.publicKey)
+
+
+          const result = await userA4.sdk.genericAction('transferLockedTokens', {
+            payeePublicKey: keys.publicKey,
+            canVote: false,
+            periods: [
+              {
+                duration: 20,
+                percent: 50.0,
+              },
+              {
+                duration: 20,
+                percent: 50.0,
+              }
+            ],
+            amount: maxTestFundsAmount,
+            maxFee: 400000000000,
+            tpid: '',
+
+          })
+          expect(result.status).to.equal('OK')
+          expect(result).to.have.all.keys('status', 'fee_collected')
+
+          console.log(" max test iteration: ", step)
+        }catch(err1){
+          console.log('failed iteraton ', err1)
+        }
+      }
+      }
+    catch
+      (err)
+      {
+        console.log('Error', err)
+      }
+
+  })
+})
 

--- a/tests/transfer-locked-tokens.js
+++ b/tests/transfer-locked-tokens.js
@@ -198,6 +198,9 @@ describe(`************************** transfer-locked-tokens.js *****************
 })
 
 //begin new tests matching testing requirements.
+//to perform max tests, comment out the tests (B,C,D), then run the load the protocol with 50k general grants
+//test (E), add the desired number of grants to the system, then skip the load the protocol with 50k general grants test (E)
+//and run (A,B,C,D). this proves the loaded system runs without issue.
 /*
 After tokens are proxied and the proxy votes 0 weight is voted
 
@@ -574,52 +577,204 @@ describe(`************************** transfer-locked-tokens.js *****************
         canVote: false,
         periods: [
           {
+            duration: 1,
+            percent: 0.273,
+          },
+          {
+            duration: 2,
+            percent: .273,
+          },
+          {
+            duration: 3,
+            percent: .273,
+          },
+          {
+            duration: 4,
+            percent: .273,
+          },
+          {
+            duration: 5,
+            percent: .273,
+          },
+          {
+            duration: 6,
+            percent: .273,
+          },
+          {
+            duration: 7,
+            percent: .273,
+          },
+          {
+            duration: 8,
+            percent: .273,
+          },
+          {
+            duration: 9,
+            percent: .273,
+          },
+          {
+            duration: 10,
+            percent: .273,
+          },
+          {
+            duration: 11,
+            percent: .273,
+          },
+          {
+            duration: 12,
+            percent: .273,
+          },
+          {
+            duration: 13,
+            percent: .273,
+          },
+          {
+            duration: 14,
+            percent: .273,
+          },
+          {
+            duration: 15,
+            percent: .273,
+          },
+          {
+            duration: 16,
+            percent: .273,
+          },
+          {
+            duration: 17,
+            percent: .273,
+          },
+          {
+            duration: 18,
+            percent: .273,
+          },
+          {
+            duration: 19,
+            percent: .273,
+          },
+          {
             duration: 20,
-            percent: 45.0,
+            percent: .273,
+          },
+          {
+            duration: 21,
+            percent: .273,
+          },
+          {
+            duration: 22,
+            percent: .273,
+          },
+          {
+            duration: 23,
+            percent: .273,
+          },
+          {
+            duration: 24,
+            percent: .273,
+          },
+          {
+            duration: 25,
+            percent: .273,
+          },
+          {
+            duration: 26,
+            percent: .273,
+          },
+          {
+            duration: 27,
+            percent: .273,
+          },
+          {
+            duration: 28,
+            percent: .273,
+          },
+          {
+            duration: 29,
+            percent: .273,
+          },
+          {
+            duration: 30,
+            percent: .273,
+          },
+          {
+            duration: 31,
+            percent: .273,
+          },
+          {
+            duration: 32,
+            percent: .273,
+          },
+          {
+            duration: 33,
+            percent: .273,
+          },
+          {
+            duration: 34,
+            percent: .273,
+          },
+          {
+            duration: 35,
+            percent: .273,
+          },
+          {
+            duration: 36,
+            percent: .273,
+          },
+          {
+            duration: 37,
+            percent: .273,
+          },
+          {
+            duration: 38,
+            percent: .273,
+          },
+          {
+            duration: 39,
+            percent: .273,
           },
           {
             duration: 40,
-            percent: 45.0,
+            percent: .273,
           },
           {
-            duration: 60,
-            percent: 1.0,
+            duration: 41,
+            percent: .273,
           },
           {
-            duration: 80,
-            percent: 1.0,
+            duration: 42,
+            percent: .273,
           },
           {
-            duration: 100,
-            percent: 1.0,
+            duration: 43,
+            percent: .273,
           },
           {
-            duration: 120,
-            percent: 1.0,
+            duration: 44,
+            percent: .273,
           },
           {
-            duration: 140,
-            percent: 1.0,
+            duration: 45,
+            percent: .273,
           },
           {
-            duration: 160,
-            percent: 1.0,
+            duration: 46,
+            percent: .273,
           },
           {
-            duration: 180,
-            percent: 1.0,
+            duration: 47,
+            percent: .273,
           },
           {
-            duration: 200,
-            percent: 1.0,
+            duration: 48,
+            percent: .273,
           },
           {
-            duration: 220,
-            percent: 1.0,
+            duration: 49,
+            percent: .273,
           },
           {
-            duration: 240,
-            percent: 1.0,
+            duration: 50,
+            percent: 86.623,
           }
         ],
         amount: fundsAmount,
@@ -635,8 +790,8 @@ describe(`************************** transfer-locked-tokens.js *****************
   })
 
 
-  it(`Waiting 20 seconds for first unlock`, async () => {
-    console.log("            waiting 20 seconds for first unlock ")
+  it(`Waiting 20 seconds`, async () => {
+    console.log("            waiting 20 seconds ")
   })
 
   it(` wait 20 seconds`, async () => {
@@ -648,7 +803,7 @@ describe(`************************** transfer-locked-tokens.js *****************
   })
 
   //try to transfer whole amount, fail.
-  it(`Transfer ${fundsAmount} Fail, fail to transfer entire amount, only half is unlocked`, async () => {
+  it(`Transfer ${fundsAmount} Fail, fail to transfer entire amount`, async () => {
     try{
     const result = await locksdk2.genericAction('transferTokens', {
       payeeFioPublicKey: userA1.publicKey,
@@ -664,18 +819,18 @@ describe(`************************** transfer-locked-tokens.js *****************
   })
 
 
-it(`Transfer ${halfundsAmount} FIO to another account`, async () => {
+it(`Transfer 1 FIO to another account`, async () => {
   const result = await locksdk2.genericAction('transferTokens', {
     payeeFioPublicKey: userA1.publicKey,
-    amount: halfundsAmount,
+    amount: 1000000000,
     maxFee: config.api.transfer_tokens_pub_key.fee,
     technologyProviderId: ''
   })
   expect(result).to.have.all.keys('transaction_id', 'block_num', 'status', 'fee_collected')
 })
 
-  it(`Waiting 20 seconds for second unlock`, async () => {
-    console.log("            waiting 20 seconds for second unlock ")
+  it(`Waiting 20 seconds`, async () => {
+    console.log("            waiting 20 seconds ")
   })
 
 it(` wait 20 seconds`, async () => {
@@ -687,15 +842,36 @@ it(` wait 20 seconds`, async () => {
 })
 
 
-it(`Transfer ${halfundsAmount} FIO to another account`, async () => {
+it(`Transfer 5 FIO to another account`, async () => {
   const result = await locksdk2.genericAction('transferTokens', {
     payeeFioPublicKey: userA1.publicKey,
-    amount: halfundsAmount,
+    amount: 5000000000,
     maxFee: config.api.transfer_tokens_pub_key.fee,
     technologyProviderId: ''
   })
   expect(result).to.have.all.keys('transaction_id', 'block_num', 'status', 'fee_collected')
 })
+
+  it(`Waiting 20 seconds`, async () => {
+    console.log("            waiting 20 seconds ")
+  })
+  it(` wait 20 seconds`, async () => {
+    try {
+      wait(20000)
+    } catch (err) {
+      console.log('Error', err)
+    }
+  })
+
+  it(`Transfer 400 FIO to another account`, async () => {
+    const result = await locksdk2.genericAction('transferTokens', {
+      payeeFioPublicKey: userA1.publicKey,
+      amount: 400000000000,
+      maxFee: config.api.transfer_tokens_pub_key.fee,
+      technologyProviderId: ''
+    })
+    expect(result).to.have.all.keys('transaction_id', 'block_num', 'status', 'fee_collected')
+  })
 
 })
 
@@ -703,8 +879,9 @@ it(`Transfer ${halfundsAmount} FIO to another account`, async () => {
 let accounts = [], privkeys = [], pubkeys = []
 let lockholder
 
-//comment out other tests, then run this test, then after running, re-run the other tests in order to test the
-//system loaded up with a decent number of general locked token grants.
+//to perform max tests, comment out the tests (B,C,D), then run the load the protocol with 50k general grants
+//test (E), add the desired number of grants to the system, then skip the load the protocol with 50k general grants test (E)
+//and run (A,B,C,D). this proves the loaded system runs without issue.
 describe(`************************** transfer-locked-tokens.js ************************** \n E. MAX tests`, () => {
 
   it.skip(`load the protocol with 50k general grants`, async () => {
@@ -730,12 +907,204 @@ describe(`************************** transfer-locked-tokens.js *****************
             canVote: false,
             periods: [
               {
+                duration: 1,
+                percent: 0.273,
+              },
+              {
+                duration: 2,
+                percent: .273,
+              },
+              {
+                duration: 3,
+                percent: .273,
+              },
+              {
+                duration: 4,
+                percent: .273,
+              },
+              {
+                duration: 5,
+                percent: .273,
+              },
+              {
+                duration: 6,
+                percent: .273,
+              },
+              {
+                duration: 7,
+                percent: .273,
+              },
+              {
+                duration: 8,
+                percent: .273,
+              },
+              {
+                duration: 9,
+                percent: .273,
+              },
+              {
+                duration: 10,
+                percent: .273,
+              },
+              {
+                duration: 11,
+                percent: .273,
+              },
+              {
+                duration: 12,
+                percent: .273,
+              },
+              {
+                duration: 13,
+                percent: .273,
+              },
+              {
+                duration: 14,
+                percent: .273,
+              },
+              {
+                duration: 15,
+                percent: .273,
+              },
+              {
+                duration: 16,
+                percent: .273,
+              },
+              {
+                duration: 17,
+                percent: .273,
+              },
+              {
+                duration: 18,
+                percent: .273,
+              },
+              {
+                duration: 19,
+                percent: .273,
+              },
+              {
                 duration: 20,
-                percent: 50.0,
+                percent: .273,
+              },
+              {
+                duration: 21,
+                percent: .273,
+              },
+              {
+                duration: 22,
+                percent: .273,
+              },
+              {
+                duration: 23,
+                percent: .273,
+              },
+              {
+                duration: 24,
+                percent: .273,
+              },
+              {
+                duration: 25,
+                percent: .273,
+              },
+              {
+                duration: 26,
+                percent: .273,
+              },
+              {
+                duration: 27,
+                percent: .273,
+              },
+              {
+                duration: 28,
+                percent: .273,
+              },
+              {
+                duration: 29,
+                percent: .273,
+              },
+              {
+                duration: 30,
+                percent: .273,
+              },
+              {
+                duration: 31,
+                percent: .273,
+              },
+              {
+                duration: 32,
+                percent: .273,
+              },
+              {
+                duration: 33,
+                percent: .273,
+              },
+              {
+                duration: 34,
+                percent: .273,
+              },
+              {
+                duration: 35,
+                percent: .273,
+              },
+              {
+                duration: 36,
+                percent: .273,
+              },
+              {
+                duration: 37,
+                percent: .273,
+              },
+              {
+                duration: 38,
+                percent: .273,
+              },
+              {
+                duration: 39,
+                percent: .273,
               },
               {
                 duration: 40,
-                percent: 50.0,
+                percent: .273,
+              },
+              {
+                duration: 41,
+                percent: .273,
+              },
+              {
+                duration: 42,
+                percent: .273,
+              },
+              {
+                duration: 43,
+                percent: .273,
+              },
+              {
+                duration: 44,
+                percent: .273,
+              },
+              {
+                duration: 45,
+                percent: .273,
+              },
+              {
+                duration: 46,
+                percent: .273,
+              },
+              {
+                duration: 47,
+                percent: .273,
+              },
+              {
+                duration: 48,
+                percent: .273,
+              },
+              {
+                duration: 49,
+                percent: .273,
+              },
+              {
+                duration: 50,
+                percent: 86.623,
               }
             ],
             amount: maxTestFundsAmount,
@@ -760,4 +1129,3 @@ describe(`************************** transfer-locked-tokens.js *****************
 
   })
 })
-

--- a/tests/transfer-locked-tokens.js
+++ b/tests/transfer-locked-tokens.js
@@ -21,7 +21,7 @@ let userA1, userA2, userA3, userA4, keys, keys1, keys2, keys3, locksdk,
     total_bp_votes_before, total_bp_votes_after
 const fundsAmount = 500000000000
 const maxTestFundsAmount = 5000000000
-const halfundsAmount = 230000000000
+const halfundsAmount = 220000000000
 
 describe(`************************** transfer-locked-tokens.js ************************** \n A. Create accounts for tests`, () => {
 
@@ -56,6 +56,7 @@ describe(`************************** transfer-locked-tokens.js *****************
     console.log("              locked token holder votable priv key ",keys1.privateKey)
   })
 })
+
 
 describe(`************************** transfer-locked-tokens.js ************************** \n B. Parameter tests`, () => {
 
@@ -115,6 +116,32 @@ describe(`************************** transfer-locked-tokens.js *****************
     }
   })
 
+  it(`Transfer locked tokens, fail periods are not in ascending order of duration`, async () => {
+    try {
+      const result = await userA1.sdk.genericAction('transferLockedTokens', {
+        payeePublicKey: keys.publicKey,
+        canVote: false,
+        periods: [
+          {
+            duration: 240,
+            percent: 50.4444,
+          },
+          {
+            duration: 120,
+            percent: 49.5556,
+          }
+        ],
+        amount: fundsAmount,
+        maxFee: 400000000000,
+        tpid: '',
+
+      })
+
+    } catch (err) {
+      var expected = `Error 400`
+      expect(err.message).to.include(expected)
+    }
+  })
 
   it(`Transfer locked tokens, fail duration 0`, async () => {
     try {
@@ -247,7 +274,7 @@ describe(`************************** transfer-locked-tokens.js *****************
             percent: 40.0,
           },
           {
-            duration: 20,
+            duration: 40,
             percent: 60.0,
           }
         ],
@@ -423,7 +450,6 @@ describe(`************************** transfer-locked-tokens.js *****************
 
 //end new tests matching testing requirements.
 
-
 describe(`************************** transfer-locked-tokens.js ************************** \n C. Canvote true, verify tokens are voted.`, () => {
 
   //test cases
@@ -439,7 +465,7 @@ describe(`************************** transfer-locked-tokens.js *****************
             percent: 50.0,
           },
           {
-            duration: 20,
+            duration: 40,
             percent: 50.0,
           }
         ],
@@ -552,47 +578,47 @@ describe(`************************** transfer-locked-tokens.js *****************
             percent: 45.0,
           },
           {
-            duration: 20,
+            duration: 40,
             percent: 45.0,
           },
           {
-            duration: 20,
+            duration: 60,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 80,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 100,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 120,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 140,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 160,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 180,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 200,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 220,
             percent: 1.0,
           },
           {
-            duration: 20,
+            duration: 240,
             percent: 1.0,
           }
         ],
@@ -626,10 +652,11 @@ describe(`************************** transfer-locked-tokens.js *****************
     try{
     const result = await locksdk2.genericAction('transferTokens', {
       payeeFioPublicKey: userA1.publicKey,
-      amount: fundsAmount,
+      amount: 495000000000,
       maxFee: config.api.transfer_tokens_pub_key.fee,
       technologyProviderId: ''
     })
+      expect(result.status).to.not.equal('OK')
   } catch (err) {
     var expected = `Error 400`
     expect(err.message).to.include(expected)
@@ -707,7 +734,7 @@ describe(`************************** transfer-locked-tokens.js *****************
                 percent: 50.0,
               },
               {
-                duration: 20,
+                duration: 40,
                 percent: 50.0,
               }
             ],


### PR DESCRIPTION
this PR refines the tests for FIP-6 (general locked tokens) 
it adds 50 locking periods to the locks created.
it adds a max test.