### PR TITLE
Dependency lock.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "ethers": "^5.3.0",
         "fs": "0.0.1-security",
         "hardhat": "^2.3.0",
-        "lossless-json": "",
+        "lossless-json": "1.0.5",
         "mathjs": "^9.4.4",
         "process": "^0.11.10",
         "request": "^2.34.0",


### PR DESCRIPTION
The upgraded dependency uses the new import syntax instead of require(). Specifying the previous version for now. 