### PR TITLE
 BD-4669  changes to FIO.test

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ describe('TEST SUITE', () => {
 
   describe('** GENERAL TESTS - NO SETUP **', () => {
 
+    require('./tests/BD-4669-auditvote-with-staking-and-locks.js');
     //FIP-40 tests
     require("./tests/FIP-40-permissions-dev-tests.js");
 

--- a/tests/BD-4669-auditvote-with-staking-and-locks.js
+++ b/tests/BD-4669-auditvote-with-staking-and-locks.js
@@ -527,11 +527,7 @@ describe(' AE. load voters with data ordering issues, call audit vote in all pha
     }
   })
 
-
-
-
-
-  it.skip(`call audit vote until its in phase 1, max number of calls to audit vote is 20`, async () => {
+  it(`call audit vote until its in phase 1, max number of calls to audit vote is 20`, async () => {
     try {
       let audit_phase = '10'
       let last_phase = "9"

--- a/tests/BD-4669-auditvote-with-staking-and-locks.js
+++ b/tests/BD-4669-auditvote-with-staking-and-locks.js
@@ -1,0 +1,560 @@
+require('mocha')
+const {expect} = require('chai')
+const {newUser, existingUser, getTestType, getProdVoteTotal, createKeypair,getAccountFromKey, generateFioAddress, generateFioDomain, timeout, getBundleCount, getAccountVoteWeight, getTotalVotedFio, callFioApi, fetchJson} = require('../utils.js');
+const {FIOSDK } = require('@fioprotocol/fiosdk');
+const config = require('../config.js');
+const { readBufferWithDetectedEncoding } = require('tslint/lib/utils');
+const testType = getTestType();
+
+let total_voted_fio, transfer_tokens_pub_key_fee, unregister_proxy_fee, register_proxy_fee
+
+const eosio = {
+  account: 'eosio',
+  publicKey: 'FIO7isxEua78KPVbGzKemH4nj2bWE52gqj8Hkac3tc7jKNvpfWzYS',
+  privateKey: '5KBX1dwHME4VyuUss2sYM25D5ZTDvyYrbEz37UJqwAVAsR4tGuY'
+}
+
+const fiotoken = {
+  account: 'fio.token',
+  publicKey: 'FIO7isxEua78KPVbGzKemH4nj2bWE52gqj8Hkac3tc7jKNvpfWzYS',
+  privateKey: '5KBX1dwHME4VyuUss2sYM25D5ZTDvyYrbEz37UJqwAVAsR4tGuY'
+}
+
+before(async () => {
+  faucet = new FIOSDK(config.FAUCET_PRIV_KEY, config.FAUCET_PUB_KEY, config.BASE_URL, fetchJson);
+
+  result = await faucet.getFee('transfer_tokens_pub_key');
+  transfer_tokens_pub_key_fee = result.fee;
+
+  result = await faucet.getFee('unregister_proxy');
+  unregister_proxy_fee = result.fee;
+
+  result = await faucet.getFee('register_proxy');
+  register_proxy_fee = result.fee;
+})
+
+describe(' AE. load voters with data ordering issues, call audit vote in all phases', () => {
+  let voter1, phase_change = 0
+  let voter2,voter3,voter4,voter5,voter6;
+  let auditacc;
+  let keys1, keys2;
+  let key1sdk, key2sdk;
+  let keys1account, keys2account;
+
+  it(`Create users`, async () => {
+    voter1 = await newUser(faucet);
+    voter2 = await newUser(faucet);
+    voter3 = await newUser(faucet);
+    voter4 = await newUser(faucet);
+    voter5 = await newUser(faucet);
+    voter6 = await newUser(faucet);
+
+    auditacc = await newUser(faucet);
+    keys1 = await createKeypair();
+    keys2 = await createKeypair();
+
+
+    let taccsdk = await new FIOSDK(keys.privateKey, keys.publicKey, config.BASE_URL, fetchJson);
+    let taccount = await getAccountFromKey(keys.publicKey);
+  })
+
+  it(`Wait a few seconds.`, async () => { await timeout(3000) })
+
+  //transfer locked tokens to voter 2,3
+  it(`transfer locked tokens to voter2`, async () => {
+    try {
+      const result = await auditacc.sdk.genericAction('pushTransaction', {
+        action: 'trnsloctoks',
+        account: 'fio.token',
+        data: {
+          payee_public_key: keys1.publicKey,
+          can_vote: 0,
+          periods: [
+            {
+              duration: 20,
+              amount: 100000000000,
+            },
+            {
+              duration: 30000000,
+              amount: 100000000000,
+            }
+          ],
+          amount: 200000000000,
+          max_fee: config.maxFee,
+          tpid: '',
+          actor: auditacc.account,
+        }
+
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+
+
+  //send alittle more to account so it can operate and vote
+
+  it(`transfer some tokens to keys1`, async () => {
+    try {
+      const result = await faucet.genericAction('transferTokens', {
+        payeeFioPublicKey: keys1.publicKey,
+        amount: 550000000000,
+        maxFee: config.api.transfer_tokens_pub_key.fee,
+        technologyProviderId: ''
+      })
+
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+
+  it(`transfer locked tokens to voter3`, async () => {
+    try {
+      const result = await auditacc.sdk.genericAction('pushTransaction', {
+        action: 'trnsloctoks',
+        account: 'fio.token',
+        data: {
+          payee_public_key: keys2.publicKey,
+          can_vote: 0,
+          periods: [
+            {
+              duration: 20,
+              amount: 100000000000,
+            },
+            {
+              duration: 30000000,
+              amount: 100000000000,
+            }
+          ],
+          amount: 200000000000,
+          max_fee: config.maxFee,
+          tpid: '',
+          actor: auditacc.account,
+        }
+
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+  it(`transfer some tokens to keys2`, async () => {
+    try {
+      const result = await faucet.genericAction('transferTokens', {
+        payeeFioPublicKey: keys2.publicKey,
+        amount: 550000000000,
+        maxFee: config.api.transfer_tokens_pub_key.fee,
+        technologyProviderId: ''
+      })
+
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+
+  it(`voter1 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await voter1.sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: voter1.address,
+          actor: voter1.account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+  it(`voter2 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await voter2.sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: voter2.address,
+          actor: voter2.account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+  it(`voter3 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await voter3.sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: voter3.address,
+          actor: voter3.account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+  it(`voter4 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await voter4.sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: voter4.address,
+          actor: voter4.account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+  it(`voter5 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await voter5.sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: voter5.address,
+          actor: voter5.account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+
+  it(`Success, stake voter5 450 tokens `, async () => {
+    try{
+      const result = await voter5.sdk.genericAction('pushTransaction', {
+        action: 'stakefio',
+        account: 'fio.staking',
+        data: {
+          fio_address: voter5.address,
+          amount: 450000000000,
+          actor: voter5.account,
+          max_fee: config.maxFee,
+          tpid:''
+        }
+      })
+      // console.log('Result: ', result)
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+  it(`voter6 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await voter6.sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: voter6.address,
+          actor: voter6.account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+
+  it(`Set voter1 domain as public so newkeypair can register address on it`, async () => {
+    const result = await voter1.sdk.genericAction('setFioDomainVisibility', {
+      fioDomain: voter1.domain,
+      isPublic: true,
+      maxFee: config.maxFee
+    })
+    //console.log('Result: ', result)
+    expect(result.status).to.equal('OK')
+    //const result = await user1Ram.setRamData('SETDOMAINPUBRAM', user1Ram)
+  })
+
+  it(`regaddress for keys1 so it can vote`, async () => {
+    try {
+      keys1.address = await generateFioAddress(voter1.domain, 8)
+      key1sdk = await new FIOSDK(keys1.privateKey, keys1.publicKey, config.BASE_URL, fetchJson);
+      keys1account = await getAccountFromKey(keys1.publicKey);
+      const result = await key1sdk.genericAction('pushTransaction', {
+        action: 'regaddress',
+        account: 'fio.address',
+        data: {
+          fio_address: keys1.address,
+          owner_fio_public_key: keys1.publicKey,
+          max_fee: config.maxFee,
+          tpid: ''
+        }
+      })
+      //console.log('Result: ', result);
+      expect(result.status).to.equal('OK');
+    } catch (err) {
+      console.log('Error: ', err)
+      expect(err).to.equal('null')
+    }
+  })
+
+  it(`regaddress for keys2 so it can vote`, async () => {
+    try {
+      keys2.address = await generateFioAddress(voter1.domain, 8)
+      key2sdk = await new FIOSDK(keys2.privateKey, keys2.publicKey, config.BASE_URL, fetchJson);
+      keys2account = await getAccountFromKey(keys2.publicKey);
+      const result = await key2sdk.genericAction('pushTransaction', {
+        action: 'regaddress',
+        account: 'fio.address',
+        data: {
+          fio_address: keys2.address,
+          owner_fio_public_key: keys2.publicKey,
+          max_fee: config.maxFee,
+          tpid: ''
+        }
+      })
+      //console.log('Result: ', result);
+      expect(result.status).to.equal('OK');
+    } catch (err) {
+      console.log('Error: ', err)
+      expect(err).to.equal('null')
+    }
+  })
+
+  it(`keys1 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await key1sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: keys1.address,
+          actor: keys1account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+  it(`keys2 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await key2sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: keys2.address,
+          actor: keys2account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+  it(`Register voter5 as a proxy`, async () => {
+    try {
+      const result = await voter5.sdk.genericAction('pushTransaction', {
+        action: 'regproxy',
+        account: 'eosio',
+        data: {
+          fio_address: voter5.address,
+          actor: voter5.account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      expect(err).to.equal('null')
+    }
+  })
+
+  it(`Wait a few seconds.`, async () => { await timeout(3000) })
+
+
+
+  it(`voter5 votes for bp1@dapixdev using address #1`, async () => {
+    try {
+      const result = await voter5.sdk.genericAction('pushTransaction', {
+        action: 'voteproducer',
+        account: 'eosio',
+        data: {
+          "producers": [
+            'bp1@dapixdev'
+          ],
+          fio_address: voter5.address,
+          actor: voter5.account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+      expect(err).to.equal('null')
+    }
+  })
+
+  //now make voter2,3 to proxy to voter5
+  it(`voter2 proxy votes to voter5`, async () => {
+    try {
+      const result = await voter2.sdk.genericAction('pushTransaction', {
+        action: 'voteproxy',
+        account: 'eosio',
+        data: {
+          proxy: voter5.address,
+          fio_address: voter2.address,
+          actor: voter2.account,
+          max_fee: config.api.proxy_vote.fee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+  it(`voter3 proxy votes to voter5`, async () => {
+    try {
+      const result = await voter3.sdk.genericAction('pushTransaction', {
+        action: 'voteproxy',
+        account: 'eosio',
+        data: {
+          proxy: voter5.address,
+          fio_address: voter3.address,
+          actor: voter3.account,
+          max_fee: config.api.proxy_vote.fee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+
+  it(`Success, stake voter5 450 tokens `, async () => {
+    try{
+      const result = await voter5.sdk.genericAction('pushTransaction', {
+        action: 'unstakefio',
+        account: 'fio.staking',
+        data: {
+          fio_address: voter5.address,
+          amount: 225000000000,
+          actor: voter5.account,
+          max_fee: config.maxFee,
+          tpid:''
+        }
+      })
+      // console.log('Result: ', result)
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+  it(`keys1 proxy votes to voter5`, async () => {
+    try {
+      const result = await key1sdk.genericAction('pushTransaction', {
+        action: 'voteproxy',
+        account: 'eosio',
+        data: {
+          proxy: voter5.address,
+          fio_address: keys1.address,
+          actor: keys1account,
+          max_fee: config.api.proxy_vote.fee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
+
+
+
+
+
+  it.skip(`call audit vote until its in phase 1, max number of calls to audit vote is 20`, async () => {
+    try {
+      let audit_phase = '10'
+      let last_phase = "9"
+      let n_called = 0;
+      let max_calls_audit = 100
+      console.log("this test will call audit a max of "+max_calls_audit+" times")
+
+      while(((audit_phase.localeCompare('4') != 0) || (phase_change < 3)) ) {
+        n_called++;
+        const result = await auditacc.sdk.genericAction('pushTransaction', {
+          action: 'auditvote',
+          account: 'eosio',
+          data: {
+            actor: auditacc.account,
+            max_fee: config.api.audit_vote.fee
+          }
+        })
+        audit_phase = result.audit_phase
+
+        //if there is lots of voters the account may run out of funds and
+        //throw exceptions...
+        if(n_called > max_calls_audit) break;
+
+        if(last_phase.localeCompare(audit_phase) != 0){
+          if(last_phase.localeCompare("9") != 0){
+            phase_change ++
+          }
+          last_phase = audit_phase;
+
+        }
+        console.log("completed call to audit vote, audit phase "+result.audit_phase)
+        console.log("          records processed "+result.records_processed)
+        expect(result.status).to.equal('OK')
+        expect(result.fee_collected).to.equal(config.api.audit_vote.fee)
+
+        await timeout(3000)
+      }
+    } catch (err) {
+      console.log('Error: ', err);
+      expect(err).to.equal('null');
+    }
+  })
+
+
+})

--- a/tests/BD-4669-auditvote-with-staking-and-locks.js
+++ b/tests/BD-4669-auditvote-with-staking-and-locks.js
@@ -71,11 +71,11 @@ describe(' AE. load voters with data ordering issues, call audit vote in all pha
           can_vote: 0,
           periods: [
             {
-              duration: 20,
+              duration: 2628000,
               amount: 100000000000,
             },
             {
-              duration: 30000000,
+              duration: 2629000,
               amount: 100000000000,
             }
           ],
@@ -120,11 +120,11 @@ describe(' AE. load voters with data ordering issues, call audit vote in all pha
           can_vote: 0,
           periods: [
             {
-              duration: 20,
+              duration: 2628000,
               amount: 100000000000,
             },
             {
-              duration: 30000000,
+              duration: 2629000,
               amount: 100000000000,
             }
           ],
@@ -330,6 +330,7 @@ describe(' AE. load voters with data ordering issues, call audit vote in all pha
     }
   })
 
+
   it(`regaddress for keys2 so it can vote`, async () => {
     try {
       keys2.address = await generateFioAddress(voter1.domain, 8)
@@ -393,6 +394,23 @@ describe(' AE. load voters with data ordering issues, call audit vote in all pha
       expect(err).to.equal('null')
     }
   })
+  //register keys1 as proxy
+  it(`Register keys1 as a proxy`, async () => {
+    try {
+      const result = await key1sdk.genericAction('pushTransaction', {
+        action: 'regproxy',
+        account: 'eosio',
+        data: {
+          fio_address: keys1.address,
+          actor: keys1account,
+          max_fee: config.maxFee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      expect(err).to.equal('null')
+    }
+  })
   it(`Register voter5 as a proxy`, async () => {
     try {
       const result = await voter5.sdk.genericAction('pushTransaction', {
@@ -412,6 +430,24 @@ describe(' AE. load voters with data ordering issues, call audit vote in all pha
 
   it(`Wait a few seconds.`, async () => { await timeout(3000) })
 
+  //keys2 proxy to keys1
+  it(`keys2 proxy votes to keys1`, async () => {
+    try {
+      const result = await key2sdk.genericAction('pushTransaction', {
+        action: 'voteproxy',
+        account: 'eosio',
+        data: {
+          proxy: keys1.address,
+          fio_address: keys2.address,
+          actor: keys2account,
+          max_fee: config.api.proxy_vote.fee
+        }
+      })
+      expect(result.status).to.equal('OK')
+    } catch (err) {
+      console.log('Error: ', err.json)
+    }
+  })
 
 
   it(`voter5 votes for bp1@dapixdev using address #1`, async () => {
@@ -485,23 +521,6 @@ describe(' AE. load voters with data ordering issues, call audit vote in all pha
         }
       })
       // console.log('Result: ', result)
-      expect(result.status).to.equal('OK')
-    } catch (err) {
-      console.log('Error: ', err.json)
-    }
-  })
-  it(`keys1 proxy votes to voter5`, async () => {
-    try {
-      const result = await key1sdk.genericAction('pushTransaction', {
-        action: 'voteproxy',
-        account: 'eosio',
-        data: {
-          proxy: voter5.address,
-          fio_address: keys1.address,
-          actor: keys1account,
-          max_fee: config.api.proxy_vote.fee
-        }
-      })
       expect(result.status).to.equal('OK')
     } catch (err) {
       console.log('Error: ', err.json)

--- a/tools/perform_vote_power_analysis.js
+++ b/tools/perform_vote_power_analysis.js
@@ -45,7 +45,7 @@ const onNetAccount = {
   account: 'v2lgwcdkb5gn',
   publicKey: 'FIO8k7N7jU9eyj57AfazGxMuvPGZG5hvXNUyxt9pBchnkXXx9KUuD',
   privateKey: '5Jw78NzS2QMvjcyemCgJ9XQv8SMSEvTEuLxF8TcKf27xWcX5fmw'
-}
+  }
 const sdkAcc = {
   sdk: 'somefin'
 }
@@ -68,7 +68,7 @@ analysis_account = tacc;
  */
 
 before(async () => {
-  //local private network setup
+//local private network setup
   faucet = new FIOSDK(config.FAUCET_PRIV_KEY, config.FAUCET_PUB_KEY, config.BASE_URL, fetchJson);
   analysis_account = await newUser(faucet);
 })
@@ -320,7 +320,7 @@ it will output several csv files, it will remove and overwrite the files if they
           if (balancekey.balance != balancekey.available) {
             var can_vote = await get_locks_vote(voter.owner);
             if (can_vote == 0) {
-              token_power = balancekey.available;
+              token_power = balancekey.available / 1000000000;
             }
           }
           console.log(" VOTER ID ",voter.id)
@@ -332,6 +332,7 @@ it will output several csv files, it will remove and overwrite the files if they
               tp += voter.producers[p]
             }
           }
+         
           var voteritem = {
             owner: voter.owner,
             proxied_vote_weight: voter.proxied_vote_weight / 1000000000,
@@ -482,6 +483,57 @@ it will output several csv files, it will remove and overwrite the files if they
     }
     console.log("analysis completed!!! output dir is "+OUTPUTDIR);
 
+  })
+
+
+  describe.skip(' A. Send 1 FIO to all voters...', () => {
+    it(`Sending...`, async () => {
+      let calling_account = await newUser(faucet);
+
+      let voter_rows = Array();
+      let bad_voters = Array();
+
+      // Establish Voters
+      console.log("Fetching voters and computing power...");
+      let limit = 900;
+      let start = 0;
+      let ix = 0;
+
+      let voters = await get_voters(start,limit);
+      console.log("Fetched voters start limit,"+start+" "+limit);
+      while (voters.rows.length > 0) {
+        console.log("the number of rows is " + voters.rows.length);
+        for (let i=0;i<voters.rows.length;i++) {
+          let voter = voters.rows[i]
+          ix++;
+          try {
+            let voter_pub_key = await get_pub_key(voter.owner)
+            console.log("Sending funds to ", voter.owner);
+            await calling_account.sdk.genericAction('pushTransaction', {
+              action: 'trnsfiopubky',
+              account: 'fio.token',
+              data: {
+                payee_public_key: voter_pub_key,
+                amount: 1000000000,
+                max_fee: config.maxFee,
+                actor: calling_account.account,
+                tpid: ''
+              }
+            });
+          } catch (error) {
+            console.log("unexpected error processing funding; voter " + voter.owner + " " + error);
+            bad_voters.push(voter.owner);
+          }
+        }
+
+        start = start + voters.rows.length;
+        voters = await get_voters(start, limit);
+        console.log("Fetched voters start limit," + start + " " + limit);
+      }
+      bad_voters.forEach(function(item, index) {
+        console.log(index + ": " + item);
+      });
+    })
   })
 
 


### PR DESCRIPTION
add new tests that have voters and proxies with locked and staked tokens.
this new BD-4669 test needs added to the general tests for regression.
manual procedures for testing are
run the BD-4669 js test
run the vote power analysis
note that the voters, and producers vote results are computed by audit to be accurate.

This PR also resolves an error in the voting analysis that was serving to mask the issue with  the audit....
when the voting analysis was getting voting power of an account it wassailing to convert the available balance to FIO from SUF. This introduced inaccuracy into the voting power results produced by the analysis when staked tokens or locked tokens were held by voting proxies.